### PR TITLE
Add rust 1.47 support

### DIFF
--- a/src/install_user.sh
+++ b/src/install_user.sh
@@ -5,4 +5,5 @@ set -e
 go get -u -v github.com/tcnksm/ghr
 
 curl https://sh.rustup.rs -sSf | bash -s -- -y
+/tmp/install_rust.sh 1.47.0         # Install rust 1.47 (required by zcash apps)
 /tmp/install_rust.sh 1.49.0         # Install rust 1.49 (required by substrate apps)


### PR DESCRIPTION
Add rust 1.47 again to support crates on zcash