### PR TITLE
fix(ledger-app-builder): restore /usr/bin/ld.lld for clang -fuse-ld=lld

### DIFF
--- a/ledger-app-builder/Dockerfile
+++ b/ledger-app-builder/Dockerfile
@@ -2,6 +2,19 @@ FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
 RUN apt-get update && apt-get install -y bear clang libclang-dev && rm -rf /var/lib/apt/lists/* # allows compile_commands.json generation
 
+# The `clang` installed just above is Debian's (clang-19 on the trixie base) and ships
+# no lld; it shadows the upstream clang-N as the driver that links the app. The secure
+# SDKs link with `clang -fuse-ld=lld` (e.g. /opt/apex-secure-sdk Makefile.rules_generic),
+# and Debian clang finds no `ld.lld` on its search path (only the upstream `ld.lld-N`
+# exists, unversioned at /usr/bin/ld.lld is gone since the trixie/versioned-LLVM move),
+# so the link fails with "invalid linker name in argument '-fuse-ld=lld'". The pre-trixie
+# image had /usr/bin/ld.lld on PATH; restore it (version-agnostically) so clang+LLD links.
+RUN set -eu; \
+    target="$(ls /usr/bin/ld.lld-* 2>/dev/null | sort -V | tail -n1)"; \
+    test -n "$target"; \
+    update-alternatives --install /usr/bin/ld.lld ld.lld "$target" 100; \
+    ld.lld --version
+
 # for rust-based apps
 RUN rustup target add thumbv6m-none-eabi
 RUN rustup target add thumbv8m.main-none-eabi


### PR DESCRIPTION
## Problem

Apex builds across our Ledger apps started failing at **link time** after the `zondax/ledger-app-builder:latest` image was rebuilt (auto weekly upstream pull, ~2026-06-08):

```
[LINK] build/apex_p/bin/app.elf
clang: error: invalid linker name in argument '-fuse-ld=lld'
make[1]: *** [/opt/apex-secure-sdk/Makefile.rules_generic:157: build/apex_p/bin/app.elf] Error 1
```

Only the apex target breaks because it's the only SDK that links via `clang -fuse-ld=lld` (the others use `arm-none-eabi-gcc`).

## Root cause

This is **not** an app bug and **not** an upstream LedgerHQ bug — the pure `ghcr.io/ledgerhq/.../ledger-app-builder:latest` image links fine (its clang-21 resolves `ld.lld` from `/usr/lib/llvm-21/bin`).

The regression is introduced **by this image's `apt-get install clang` layer**, combined with the upstream base moving to **Debian trixie**:

- `apt install clang` on trixie pulls **Debian clang-19**, which ships **no lld** and shadows the upstream clang as the driver that links the app.
- The trixie / versioned-LLVM move dropped the unversioned `/usr/bin/ld.lld` that older images provided, so Debian's clang finds no `ld.lld` anywhere on its search path → `invalid linker name`.

The pre-trixie image had `/usr/bin/ld.lld` on PATH, which is why this used to work.

## Fix

Restore `/usr/bin/ld.lld` via `update-alternatives`, pointing at the upstream `ld.lld-N` that's already present (version-agnostic glob, so it survives future clang bumps). The build self-checks with `ld.lld --version`, so a missing/broken linker fails the image build loudly instead of shipping broken.

This matches the linker layout the pre-trixie image provided and unblocks apex builds for every app using this builder.